### PR TITLE
Runbook release for January 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file
 
+## v21.1.0
+
+### Added
+
+* Adds pod Anti-affinity rules to distribute a replica across the availability zones, and nodes within them.
+* Activate logout for SAML when using single sign-on (SSO)
 
 ## v20.12.0
 

--- a/helm-charts/apps/Chart.yaml
+++ b/helm-charts/apps/Chart.yaml
@@ -29,7 +29,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 3.2.2
+version: 3.3.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/apps/RELEASENOTES.md
+++ b/helm-charts/apps/RELEASENOTES.md
@@ -12,6 +12,11 @@
 
 # Version History
 
+## v3.3.0
+
+* Adds pod Anti-affinity rules to distribute a replica across the availability zones, and nodes within them.
+* Activate logout for SAML when using single sign-on (SSO)
+
 ## v3.2.2
 
 * Adds values from `podAnnotations` at deployment

--- a/helm-charts/apps/templates/configmaps/configmap-isam.yaml
+++ b/helm-charts/apps/templates/configmaps/configmap-isam.yaml
@@ -2,7 +2,7 @@
 {{- if $.Values.global.isam.enabled }}
 ---
 ###############################################################################
-# Copyright 2019,2020 IBM Corporation
+# Copyright 2019,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,7 +42,8 @@ data:
         spHostAndPort="{{ $.Values.global.ingress.hostname}}"
         disableLtpaCookie="false"
         allowCustomCacheKey="false"
-        enabled="true">
+        enabled="true"
+        spLogout="true">
       </samlWebSso20>
 
       <authFilter id="curamAuthFilter">

--- a/helm-charts/apps/templates/deployment-consumer.yaml
+++ b/helm-charts/apps/templates/deployment-consumer.yaml
@@ -47,6 +47,26 @@ spec:
       {{- include "sch.security.securityContext" (list $ $.sch.chart.podSecurityContext) | indent 6 }}
       affinity:
         {{- include "sch.affinity.nodeAffinity" (list $ $.sch.chart.nodeAffinity) | indent 8 }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - {{ (printf "%s-consumer" $name) }}
+              topologyKey: topology.kubernetes.io/zone
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - {{ (printf "%s-consumer" $name) }}
+              topologyKey: kubernetes.io/hostname
       {{- if or $.Values.global.imagePullSecret.secretName $.Values.global.imagePullSecret.username }}
       imagePullSecrets:
         - name: {{ default (printf "%s-pull-secret" $.Release.Name) $.Values.global.imagePullSecret.secretName }}

--- a/helm-charts/apps/templates/deployment-producer.yaml
+++ b/helm-charts/apps/templates/deployment-producer.yaml
@@ -46,6 +46,26 @@ spec:
       {{- include "sch.security.securityContext" (list $ $.sch.chart.podSecurityContext) | nindent 6 }}
       affinity:
         {{- include "sch.affinity.nodeAffinity" (list $ $.sch.chart.nodeAffinity) | nindent 8 }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - {{ (printf "%s-producer" $name) }}
+              topologyKey: topology.kubernetes.io/zone
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - {{ (printf "%s-producer" $name) }}
+              topologyKey: kubernetes.io/hostname
       {{- if or $.Values.global.imagePullSecret.secretName $.Values.global.imagePullSecret.username }}
       imagePullSecrets:
         - name: {{ default (printf "%s-pull-secret" $.Release.Name) $.Values.global.imagePullSecret.secretName }}

--- a/helm-charts/mqserver/Chart.yaml
+++ b/helm-charts/mqserver/Chart.yaml
@@ -29,7 +29,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 1.7.2
+version: 1.8.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/mqserver/RELEASENOTES.md
+++ b/helm-charts/mqserver/RELEASENOTES.md
@@ -10,6 +10,10 @@
 
 # Version History
 
+## v1.8.0
+
+* Adds pod Anti-affinity rules to distribute a replica across the availability zones, and nodes within them.
+
 ## v1.7.2
 
 * Added `mountOptions` value configuration to PVs and `values` file.

--- a/helm-charts/mqserver/templates/_sch-chart-config.tpl
+++ b/helm-charts/mqserver/templates/_sch-chart-config.tpl
@@ -4,6 +4,7 @@ the Shared Configurable Helpers overridden for this chart.
 */ -}}
 {{- define "mqserver.sch.chart.config.values" -}}
 sch:
+  appName: mqserver
   chart:
     nodeAffinity:
       nodeAffinityRequiredDuringScheduling:

--- a/helm-charts/mqserver/templates/deployment.yaml
+++ b/helm-charts/mqserver/templates/deployment.yaml
@@ -42,6 +42,26 @@ spec:
       {{- include "sch.security.securityContext" (list $ $.sch.chart.podSecurityContext) | nindent 6 }}
       affinity:
         {{- include "sch.affinity.nodeAffinity" (list $ $.sch.chart.nodeAffinity) | nindent 8 }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - mqserver
+              topologyKey: topology.kubernetes.io/zone
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - mqserver
+              topologyKey: kubernetes.io/hostname
       restartPolicy: {{ .restartPolicy | default "Always" }}
       volumes:
         - name: mqsc-cmds

--- a/helm-charts/spm/Chart.yaml
+++ b/helm-charts/spm/Chart.yaml
@@ -30,7 +30,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 2.3.0
+version: 2.4.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team
@@ -56,22 +56,22 @@ icon: https://avatars2.githubusercontent.com/u/1459110
 
 dependencies:
   - name: apps
-    version: "~3.2.2"
+    version: "~3.3.0"
     repository: "@local-development"
   - name: batch
     version: "~2.1.0"
     repository: "@local-development"
   - name: uawebapp
-    version: "~3.1.0"
+    version: "~3.2.0"
     repository: "@local-development"
   - name: web
-    version: "~3.1.0"
+    version: "~3.2.0"
     repository: "@local-development"
   - name: mqserver
-    version: "~1.7.2"
+    version: "~1.8.0"
     repository: "@local-development"
   - name: xmlserver
-    version: "~2.0.3"
+    version: "~2.1.0"
     repository: "@local-development"
   - name: ibm-sch
     repository: "@sch"

--- a/helm-charts/uawebapp/Chart.yaml
+++ b/helm-charts/uawebapp/Chart.yaml
@@ -30,7 +30,7 @@ description: |-
   You may obtain a copy of the License at
   
   http://www.apache.org/licenses/LICENSE-2.0
-version: 3.1.0
+version: 3.2.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/uawebapp/RELEASENOTES.md
+++ b/helm-charts/uawebapp/RELEASENOTES.md
@@ -37,6 +37,10 @@
 
 # Version History
 
+## v3.2.0
+
+* Adds pod Anti-affinity rules to distribute a replica across the availability zones, and nodes within them.
+
 ## v3.1.0
 
 * Add rewrite rule and condition to configmaps to fix verb tampering vulnerability.

--- a/helm-charts/uawebapp/templates/_sch-chart-config.tpl
+++ b/helm-charts/uawebapp/templates/_sch-chart-config.tpl
@@ -20,7 +20,21 @@ the Shared Configurable Helpers overridden for this chart.
 */ -}}
 {{- define "uawebapp.sch.chart.config.values" -}}
 sch:
+  appName: uawebapp
   chart:
+    podAntiAffinity:
+      preferredDuringScheduling:
+        uawebapp:
+          weight: 100
+          key: app.kubernetes.io/name
+          operator: In
+          topologyKey: topology.kubernetes.io/zone
+      preferredDuringScheduling:
+        uawebapp:
+          weight: 100
+          key: app.kubernetes.io/name
+          operator: In
+          topologyKey: kubernetes.io/hostname
     nodeAffinity:
       nodeAffinityRequiredDuringScheduling:
         key: beta.kubernetes.io/arch

--- a/helm-charts/uawebapp/templates/deployment.yaml
+++ b/helm-charts/uawebapp/templates/deployment.yaml
@@ -39,6 +39,7 @@ spec:
       {{- include "sch.security.securityContext" (list . .sch.chart.podSecurityContext) | nindent 6 }}
       affinity:
         {{- include "sch.affinity.nodeAffinity" (list . .sch.chart.nodeAffinity) | nindent 8 }}
+        {{- include "sch.affinity.podAntiAffinity" (list .) | nindent 8 }}
       {{- if or .Values.global.imagePullSecret.secretName .Values.global.imagePullSecret.username }}
       imagePullSecrets:
         - name: {{ default (printf "%s-pull-secret" .Release.Name) .Values.global.imagePullSecret.secretName }}

--- a/helm-charts/web/Chart.yaml
+++ b/helm-charts/web/Chart.yaml
@@ -29,7 +29,7 @@ description: |-
   You may obtain a copy of the License at
   
   http://www.apache.org/licenses/LICENSE-2.0
-version: 3.1.0
+version: 3.2.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/web/RELEASENOTES.md
+++ b/helm-charts/web/RELEASENOTES.md
@@ -11,6 +11,10 @@
 
 # Version History
 
+## v3.2.0
+
+* Adds pod Anti-affinity rules to distribute a replica across the availability zones, and nodes within them.
+
 ## v3.1.0
 
 * Add rewrite rule and condition to configmaps to fix verb tampering vulnerability.

--- a/helm-charts/web/templates/_sch-chart-config.tpl
+++ b/helm-charts/web/templates/_sch-chart-config.tpl
@@ -20,6 +20,7 @@ the Shared Configurable Helpers overridden for this chart.
 */ -}}
 {{- define "web.sch.chart.config.values" -}}
 sch:
+  appName: web
   chart:
     nodeAffinity:
       nodeAffinityRequiredDuringScheduling:

--- a/helm-charts/web/templates/deployment.yaml
+++ b/helm-charts/web/templates/deployment.yaml
@@ -38,6 +38,26 @@ spec:
       {{- include "sch.security.securityContext" (list . .sch.chart.podSecurityContext) | nindent 6 }}
       affinity:
         {{- include "sch.affinity.nodeAffinity" (list . .sch.chart.nodeAffinity) | nindent 8 }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - web
+              topologyKey: topology.kubernetes.io/zone
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - web
+              topologyKey: kubernetes.io/hostname
       {{- if or .Values.global.imagePullSecret.secretName .Values.global.imagePullSecret.username }}
       imagePullSecrets:
         - name: {{ default (printf "%s-pull-secret" .Release.Name) .Values.global.imagePullSecret.secretName }}

--- a/helm-charts/xmlserver/Chart.yaml
+++ b/helm-charts/xmlserver/Chart.yaml
@@ -30,7 +30,7 @@ description: |-
   You may obtain a copy of the License at
   
   http://www.apache.org/licenses/LICENSE-2.0
-version: 2.0.3
+version: 2.1.0
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/xmlserver/RELEASENOTES.md
+++ b/helm-charts/xmlserver/RELEASENOTES.md
@@ -10,6 +10,10 @@
 
 # Version History
 
+## v2.1.0
+
+* Adds pod Anti-affinity rules to distribute a replica across the availability zones, and nodes within them.
+
 ## v2.0.3
 
 * Update the charts to internal content verification linter standards.

--- a/helm-charts/xmlserver/templates/_sch-chart-config.tpl
+++ b/helm-charts/xmlserver/templates/_sch-chart-config.tpl
@@ -20,6 +20,7 @@ the Shared Configurable Helpers overridden for this chart.
 */ -}}
 {{- define "xmlserver.sch.chart.config.values" -}}
 sch:
+  appName: xmlserver
   chart:
     nodeAffinity:
       nodeAffinityRequiredDuringScheduling:

--- a/helm-charts/xmlserver/templates/deployment.yaml
+++ b/helm-charts/xmlserver/templates/deployment.yaml
@@ -36,9 +36,29 @@ spec:
       annotations:
         {{- include "sch.metadata.annotations.metering" (list $ $.sch.chart.metering) | nindent 8 }}
     spec:
-{{- include "sch.security.securityContext" (list . .sch.chart.podSecurityContext) | indent 6 }}
+      {{- include "sch.security.securityContext" (list . .sch.chart.podSecurityContext) | nindent 6 }}
       affinity:
-{{- include "sch.affinity.nodeAffinity" (list . .sch.chart.nodeAffinity) | indent 8 }}
+        {{- include "sch.affinity.nodeAffinity" (list . .sch.chart.nodeAffinity) | nindent 8 }}
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - xmlserver
+              topologyKey: topology.kubernetes.io/zone
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - xmlserver
+              topologyKey: kubernetes.io/hostname
       restartPolicy: {{ .restartPolicy | default "Always" }}
       {{- if or .Values.global.imagePullSecret.secretName .Values.global.imagePullSecret.username }}
       imagePullSecrets:


### PR DESCRIPTION
## v21.1.0

### Added

* Adds pod Anti-affinity rules to distribute a replica across the availability zones, and nodes within them.
* Activate logout for SAML when using single sign-on (SSO)