### PR TITLE
Fix reference to Oracle datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file
 
+## v21.5.1
+
+### Fixed
+
+* Fixed reference to Oracle datasource fragment ([#78](https://github.com/IBM/spm-kubernetes/issues/78))
+
 ## v21.5.0
 
 ### Added

--- a/helm-charts/apps/Chart.yaml
+++ b/helm-charts/apps/Chart.yaml
@@ -29,7 +29,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 3.6.0
+version: 3.6.1
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/apps/RELEASENOTES.md
+++ b/helm-charts/apps/RELEASENOTES.md
@@ -23,6 +23,10 @@
 
 # Version History
 
+## v3.6.1
+
+* Fix reference to Oracle datasource fragment
+
 ## v3.6.0
 
 * Add ability to tune K8s resources on an app by app basis

--- a/helm-charts/apps/templates/_database.tpl
+++ b/helm-charts/apps/templates/_database.tpl
@@ -47,7 +47,7 @@ Liberty Datastore properties fragment
 />
 {{- else if eq ($dbConfig.type | upper) "ORA" -}}
 <properties.oracle
-  URL="{{ include "apps.oracleurl" . }}"
+  URL="{{ include "apps.oracleurl" $root }}"
   password="${env.XOR_DB_PSW}"
   user="${env.SPM_DB_USR}"
 />

--- a/helm-charts/spm/Chart.yaml
+++ b/helm-charts/spm/Chart.yaml
@@ -30,7 +30,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 2.7.0
+version: 2.7.1
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/spm/RELEASENOTES.md
+++ b/helm-charts/spm/RELEASENOTES.md
@@ -11,6 +11,10 @@
 
 # Version History
 
+## v2.7.1
+
+* Update `apps` dependency to version 3.6.1
+
 ## v2.7.0
 
 * Update `apps` dependency to version 3.6.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spm-kubernetes",
-  "version": "21.5.0",
+  "version": "21.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spm-kubernetes",
   "private": true,
-  "version": "21.5.0",
+  "version": "21.5.1",
   "license": "Apache 2.0",
   "scripts": {
     "dev": "gatsby develop -H 0.0.0.0",


### PR DESCRIPTION
## v21.5.1

### Fixed

* Fixed reference to Oracle datasource fragment ([#78](https://github.com/IBM/spm-kubernetes/issues/78))

Signed-off-by: Andrey Zhereshchin <andrey.zhereshchin@ie.ibm.com>