### PR TITLE
September 2021 release v7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file
 
+## v21.6.3
+
+### Added
+
+* Add a startup probe to the `apps` producer and consumers pods
+
+### Changed
+
+* Updated WebSphere Liberty version to include 21.0.0.9
+* The following helm-charts have been updated to chart version `21.6.3`: `apps`, `batch`, `mqserver`, `spm`, `uawebapp`, `web`, `xmlserver`.
+* Timeout for linkchecker updated from 60 to 120
+* Update the readiness probe of the `apps` producer and consumers pods, consider a pod ready if curl to application link gives successful response or if codes 'CWWKZ0001I & CWWKF0011I' are found in message logs.
+* Updated the liveness probe to check only the last 1000 lines of the logs file
+* Updated support statement for Helm v3 in prerequisite
+  * Due to breaking changes in Helm release `v3.7.0`, IBM Cúram Social Program Management only supports up to Helm `v3.6.3`
+
+### Fixed
+
+* Restore setting of environment variable `POD_HOSTNAME` in Liberty `server.xml` for the `apps` producer and consumers pods
+
 ## v21.6.2
 
 ### Breaking Changes

--- a/dockerfiles/Liberty/Batch.Dockerfile
+++ b/dockerfiles/Liberty/Batch.Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 ###############################################################################
 
-ARG WLP_VERSION=20.0.0.9-full-java8-ibmjava-ubi
+ARG WLP_VERSION=21.0.0.9-full-java8-ibmjava-ubi
 ARG ANT_VERSION=1.10.6
 
 # Intermediate image: extract Ant

--- a/dockerfiles/Liberty/ClientEAR.Dockerfile
+++ b/dockerfiles/Liberty/ClientEAR.Dockerfile
@@ -16,7 +16,7 @@
 
 ARG EAR_NAME
 ARG SERVERCODE_IMAGE=servercode:latest
-ARG WLP_VERSION=20.0.0.9-full-java8-ibmjava-ubi
+ARG WLP_VERSION=21.0.0.9-full-java8-ibmjava-ubi
 
 # Explode EAR in a disposable environment
 FROM alpine AS ExplodedEAR

--- a/dockerfiles/Liberty/ServerEAR.Dockerfile
+++ b/dockerfiles/Liberty/ServerEAR.Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 ###############################################################################
 
-ARG WLP_VERSION=20.0.0.9-full-java8-ibmjava-ubi
+ARG WLP_VERSION=21.0.0.9-full-java8-ibmjava-ubi
 ARG MQ_ADAPTER_VERSION=9.2.2.0
 ARG MQ_RA_LICENSE
 ARG JMX_EXPORTER_URL=https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.14.0/jmx_prometheus_javaagent-0.14.0.jar

--- a/dockerfiles/Liberty/content/liveness-probe.sh
+++ b/dockerfiles/Liberty/content/liveness-probe.sh
@@ -3,7 +3,7 @@ errorList=("The Connection Manager received a fatal connection error from the Re
 
 for i in "${errorList[@]}"
 do
-    if grep -q "$i" ${1}; then
+    if tail -n 1000 ${1} | grep -q "$i" ${1}; then
         printf "\n%sError: The following error: \n%s\"$i\" \n%s Was detected in the messages log at ${1}\n%s"
         exit 1
     else

--- a/dockerfiles/Liberty/content/readiness-probe.sh
+++ b/dockerfiles/Liberty/content/readiness-probe.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# The readiness probe is an initial draft to check if the pods are ready to take workload. If a pod is long-running we may see failures due to spill-over of the logs in the tmp/logs directory.  
+for entry in ${1}
+do
+    if ! (curl -k https://${2} | grep -q "Application is not available") || ((head -n 500 $entry | grep -q "CWWKZ0001I") && (head -n 500 $entry | grep -q "CWWKF0011I")); then
+        printf "\n%sThe application is ready to take workload."
+        exit 0
+    else
+        continue
+    fi
+done
+printf "\n%sThe application is not ready to take workload."
+exit 1

--- a/helm-charts/apps/Chart.yaml
+++ b/helm-charts/apps/Chart.yaml
@@ -29,7 +29,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 21.6.2
+version: 21.6.3
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/apps/templates/deployment-consumer.yaml
+++ b/helm-charts/apps/templates/deployment-consumer.yaml
@@ -126,6 +126,8 @@ spec:
         {{- end }}
         - name: keystore-volume
           emptyDir: {}
+        - name: jvm-volume
+          emptyDir: {}
         - name: env-volume
           emptyDir: {}
         - name: service-certs
@@ -250,8 +252,24 @@ spec:
             - -c
             - >
               {{- range (default $app.jvm $tuningParams.jvm) }}
-              echo "{{ . }}" >> /mnt/envvol/jvm.options;
+              echo "{{ . }}" >> /mnt/jvmvol/jvm.options;
               {{- end }}
+          volumeMounts:
+            - name: jvm-volume
+              mountPath: /mnt/jvmvol
+        - name: populate-server-env
+          {{- include "utilities.definition" $ | indent 10 }}
+          env:
+            - name: podHostname
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+          command:
+            - /bin/sh
+            - -c
+            - >
+              echo "POD_HOSTNAME=$podHostname" | sed "s/-/_/g" > /mnt/envvol/server.env;
           volumeMounts:
             - name: env-volume
               mountPath: /mnt/envvol
@@ -328,20 +346,34 @@ spec:
             {{- end }}
             - name: TZ
               value: {{ $.Values.global.timezone }}
-          readinessProbe:
+          startupProbe:
             exec:
               command:
                 - /bin/sh
                 - -c
-                - /bin/grep "Application CuramServerCode started" {{ include "apps.logsDir" $ }}/messages*.log
-            initialDelaySeconds: 90
+                - /bin/grep "Application CuramServerCode started" {{ include "apps.logsDir" $ }}/messages.log
+            initialDelaySeconds: {{ $.Values.initialDelaySeconds }}
             periodSeconds: 10
+          {{- with .readinessPath }}
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - /opt/ibm/helpers/runtime/readiness-probe.sh {{ include "apps.logsDir" $ }}/messages*.log {{ $.Values.global.ingress.hostname }}{{ . }}
+            initialDelaySeconds: {{ $.Values.initialDelaySeconds }}
+            periodSeconds: 10
+            timeoutSeconds: 2
+          {{- end }}
           livenessProbe:
             exec:
               command:
               - /bin/sh
               - -c
               - /opt/ibm/helpers/runtime/liveness-probe.sh {{ include "apps.logsDir" $ }}/messages.log
+            initialDelaySeconds: {{ $.Values.initialDelaySeconds }}
+            periodSeconds: 10
+            timeoutSeconds: 2
           resources:
             {{- if $tuningParams.resources }}
             {{- toYaml ($tuningParams.resources) | nindent 12 }}
@@ -401,8 +433,11 @@ spec:
             - name: {{ $.Release.Name }}-persistence-volume
               mountPath: {{ include "persistence.mountPoint" $ }}
             {{- end }}
-            - name: env-volume
+            - name: jvm-volume
               mountPath: /config/jvm.options
               subPath: jvm.options
+            - name: env-volume
+              mountPath: /config/server.env
+              subPath: server.env
 {{- end }}
 {{- end }}

--- a/helm-charts/apps/templates/deployment-producer.yaml
+++ b/helm-charts/apps/templates/deployment-producer.yaml
@@ -139,6 +139,8 @@ spec:
         {{- end }}
         - name: keystore-volume
           emptyDir: {}
+        - name: jvm-volume
+          emptyDir: {}
         - name: env-volume
           emptyDir: {}
         - name: service-certs
@@ -263,8 +265,24 @@ spec:
             - -c
             - >
               {{- range (default $app.jvm $tuningParams.jvm) }}
-              echo "{{ . }}" >> /mnt/envvol/jvm.options;
+              echo "{{ . }}" >> /mnt/jvmvol/jvm.options;
               {{- end }}
+          volumeMounts:
+            - name: jvm-volume
+              mountPath: /mnt/jvmvol
+        - name: populate-server-env
+          {{- include "utilities.definition" $ | indent 10 }}
+          env:
+            - name: podHostname
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+          command:
+            - /bin/sh
+            - -c
+            - >
+              echo "POD_HOSTNAME=$podHostname" | sed "s/-/_/g" > /mnt/envvol/server.env;
           volumeMounts:
             - name: env-volume
               mountPath: /mnt/envvol
@@ -343,12 +361,14 @@ spec:
               value: {{ $.Values.global.timezone }}
           {{- with .readinessPath }}
           readinessProbe:
-            httpGet:
-              path: {{ . }}
-              port: client
-              scheme: HTTPS
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - /opt/ibm/helpers/runtime/readiness-probe.sh {{ include "apps.logsDir" $ }}/messages*.log {{ $.Values.global.ingress.hostname }}{{ . }}
             initialDelaySeconds: {{ $.Values.initialDelaySeconds }}
             periodSeconds: 10
+            timeoutSeconds: 2
           {{- end }}
           {{- if .readinessTCPProbe }}
           readinessProbe:
@@ -367,6 +387,14 @@ spec:
             initialDelaySeconds: 90
             periodSeconds: 10
           {{- end }}
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - /bin/grep -e "application available .*{{ $app.ingressPath }}" {{ include "apps.logsDir" $ }}/messages.log
+            initialDelaySeconds: {{ $.Values.initialDelaySeconds }}
+            periodSeconds: 10
           livenessProbe:
             exec:
               command:
@@ -375,6 +403,7 @@ spec:
               - /opt/ibm/helpers/runtime/liveness-probe.sh {{ include "apps.logsDir" $ }}/messages.log
             initialDelaySeconds: {{ $.Values.initialDelaySeconds }}
             periodSeconds: 10
+            timeoutSeconds: 2
           resources:
             {{- if $tuningParams.resources }}
             {{- toYaml ($tuningParams.resources) | nindent 12 }}
@@ -451,8 +480,11 @@ spec:
             - name: {{ $.Release.Name }}-persistence-volume
               mountPath: {{ include "persistence.mountPoint" $ }}
             {{- end }}
-            - name: env-volume
+            - name: jvm-volume
               mountPath: /config/jvm.options
               subPath: jvm.options
+            - name: env-volume
+              mountPath: /config/server.env
+              subPath: server.env
 {{- end }}
 {{- end }}

--- a/helm-charts/apps/values.yaml
+++ b/helm-charts/apps/values.yaml
@@ -118,7 +118,7 @@ global:
           limits:
             cpu: 1.5
             memory: 2Gi
-        readinessString: "application available .*/Rest"
+        readinessPath: /Rest/
       citizenportal:
         enabled: false
         replicaCount: 1

--- a/helm-charts/batch/Chart.yaml
+++ b/helm-charts/batch/Chart.yaml
@@ -29,7 +29,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 21.6.2
+version: 21.6.3
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/mqserver/Chart.yaml
+++ b/helm-charts/mqserver/Chart.yaml
@@ -29,7 +29,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 21.6.2
+version: 21.6.3
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/spm/Chart.yaml
+++ b/helm-charts/spm/Chart.yaml
@@ -30,7 +30,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 21.6.2
+version: 21.6.3
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team
@@ -56,22 +56,22 @@ icon: https://avatars2.githubusercontent.com/u/1459110
 
 dependencies:
   - name: apps
-    version: "~21.6.2"
+    version: "~21.6.3"
     repository: "@local-development"
   - name: batch
-    version: "~21.6.2"
+    version: "~21.6.3"
     repository: "@local-development"
   - name: uawebapp
-    version: "~21.6.2"
+    version: "~21.6.3"
     repository: "@local-development"
   - name: web
-    version: "~21.6.2"
+    version: "~21.6.3"
     repository: "@local-development"
   - name: mqserver
-    version: "~21.6.2"
+    version: "~21.6.3"
     repository: "@local-development"
   - name: xmlserver
-    version: "~21.6.2"
+    version: "~21.6.3"
     repository: "@local-development"
   - name: ibm-sch
     repository: "@sch"

--- a/helm-charts/spm/values.yaml
+++ b/helm-charts/spm/values.yaml
@@ -108,7 +108,7 @@ global:
           limits:
             cpu: 1.5
             memory: 2Gi
-        readinessString: "application available .*/Rest"
+        readinessPath: /Rest/
       citizenportal:
         enabled: false
         replicaCount: 1

--- a/helm-charts/uawebapp/Chart.yaml
+++ b/helm-charts/uawebapp/Chart.yaml
@@ -30,7 +30,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 21.6.2
+version: 21.6.3
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/web/Chart.yaml
+++ b/helm-charts/web/Chart.yaml
@@ -29,7 +29,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 21.6.2
+version: 21.6.3
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/xmlserver/Chart.yaml
+++ b/helm-charts/xmlserver/Chart.yaml
@@ -30,7 +30,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 21.6.2
+version: 21.6.3
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/linkcheckerrc
+++ b/linkcheckerrc
@@ -6,3 +6,6 @@ ignore=^http://localhost
 
 internlinks=^http://TRAVIS_HOST:8888/
 checkextern=1
+
+[checking]
+timeout=120

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spm-kubernetes",
-  "version": "21.6.2",
+  "version": "21.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spm-kubernetes",
   "private": true,
-  "version": "21.6.2",
+  "version": "21.6.3",
   "license": "Apache 2.0",
   "scripts": {
     "dev": "gatsby develop -H 0.0.0.0",

--- a/src/data/nav-items.yaml
+++ b/src/data/nav-items.yaml
@@ -81,6 +81,8 @@
       path: /monitoring/jmx-statistics-performance-monitoring/
     - title: Monitoring MQ Queue Depth Events
       path: /monitoring/mq_queue_depth_events_monitoring/
+    - title: Health Checks
+      path: /monitoring/Health Checks/  
 - title: Troubleshooting
   pages:
     - title: XML server

--- a/src/pages/build-images/setup_docker_context.mdx
+++ b/src/pages/build-images/setup_docker_context.mdx
@@ -121,7 +121,7 @@ docker run --rm \
     -u root \
     -e ANT_HOME=/tmp/ant \
     -e WLP_HOME=/opt/ibm/wlp \
-    ibmcom/websphere-liberty:20.0.0.9-full-java8-ibmjava-ubi \
+    ibmcom/websphere-liberty:21.0.0.9-full-java8-ibmjava-ubi \
     bash -c 'export PATH=$ANT_HOME/bin:$PATH:.; build.sh internal.update.crypto.jar'
 ```
 

--- a/src/pages/deployment/hc_deployment.mdx
+++ b/src/pages/deployment/hc_deployment.mdx
@@ -74,7 +74,7 @@ The respective license agreements can be reviewed by running the following comma
 
 ```shell
 # IBM WebSphere Liberty
-docker run --rm -e LICENSE=view ibmcom/websphere-liberty:20.0.0.9-full-java8-ibmjava-ubi
+docker run --rm -e LICENSE=view ibmcom/websphere-liberty:21.0.0.9-full-java8-ibmjava-ubi
 
 # IBM WebSphere MQ
 docker run --rm -e LICENSE=view ibmcom/mq:9.1.3.0

--- a/src/pages/monitoring/Health Checks.mdx
+++ b/src/pages/monitoring/Health Checks.mdx
@@ -1,0 +1,27 @@
+---
+title: Health Checks
+description: Health Checks
+---
+
+## What are health checks
+
+A health check periodically performs diagnostics on a running container to determine when a container application has started, when to restart a container and to decide if a pod should receive traffic.
+You can use the Startup, Readiness and Liveness Probes to perform the health checks.
+
+## Startup Probe
+
+A startup probe helps you to understand whether the application within a container is started.
+The liveness and readiness check is disabled until the startup probe succeeds, making sure those probes don't interfere with the application startup.
+If the startup probe does not succeed within a specified time period, the kubelet kills the container, and the container is subject to the pod restartPolicy.
+
+## Readiness Probe
+
+A readiness probe determines if a container is ready to start accepting traffic. If the readiness probe fails for a container, the kubelet removes the pod from the list of available service endpoints.
+
+## Liveness Probe
+
+A liveness probe determines if a container is still running. If the liveness probe fails the pod then responds based on its restart policy.
+
+More details about the Startup, Readiness and Liveness Probes can be found
+[here](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) on Kubernetes
+site and [here](https://docs.openshift.com/container-platform/4.6/applications/application-health.html) on OpenShift site.

--- a/src/pages/prereq/prereq.mdx
+++ b/src/pages/prereq/prereq.mdx
@@ -46,7 +46,7 @@ The technologies listed are fixed version support only, unless stated otherwise.
 
 | Supported Software                                                              | Version                   | Prerequisite Minimum  | Notes       |
 | ------------------------------------------------------------------------------- | ------------------------- | --------------------- | ----------- |
-| WebSphere Liberty                                                               | 21.0.0.0, 20.0.0.9        | 20.0.0.9              | 1           |
+| WebSphere Liberty                                                               | 21.0.0.9, 20.0.0.9        | 20.0.0.9              | 1           |
 | OpenShift ![OpenShift only](https://img.shields.io/badge/-OpenShift_only-red)   | 4.5 and future fix packs  | 4.5                   | 8,13        |
 | Kubernetes ![IKS only](https://img.shields.io/badge/-IKS_only-blue)             | 1.19 and future fix packs | 1.19                  | 2,12        |
 | IBM MQ LTS                                                                      | 9.1                       | 9.1.0.5 and future FP | 3           |
@@ -71,7 +71,7 @@ The technologies listed are fixed version support only, unless stated otherwise.
 |`(12)` &#124; Kubernetes releases a new version quarterly. When a new version is released `n-2` is deprecated, and `n-3` is unsupported. For more information please see [Kubernetes version information and update actions](https://cloud.ibm.com/docs/containers?topic=containers-cs_versions)|
 |`(13)` &#124; OpenShift releases a new version quarterly. When a new version is released `n-2` is deprecated, and `n-3` is unsupported. For more information please see [Red Hat Openshift on IBM Cloud Version information and update actions](https://cloud.ibm.com/docs/openshift?topic=openshift-openshift_versions), and [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)|
 |`(14)` &#124; IBM Cúram Social Program Management uses Docker only to build container images, IBM Cúram Social Program Management do not use Docker as a container runtime engine.|
-|`(13)` &#124; Due to breaking changes in Helm release `v3.7.0`, IBM Cúram Social Program Management only supports up to Helm `v3.6.3`|
+|`(15)` &#124; Due to breaking changes in Helm release `v3.7.0`, IBM Cúram Social Program Management only supports up to Helm `v3.6.3`|
 
 </AccordionItem>
 

--- a/src/pages/prereq/prereq.mdx
+++ b/src/pages/prereq/prereq.mdx
@@ -46,14 +46,14 @@ The technologies listed are fixed version support only, unless stated otherwise.
 
 | Supported Software                                                              | Version                   | Prerequisite Minimum  | Notes       |
 | ------------------------------------------------------------------------------- | ------------------------- | --------------------- | ----------- |
-| WebSphere Liberty                                                               | 20.0.0.9                  | 20.0.0.9              | 1           |
+| WebSphere Liberty                                                               | 21.0.0.0, 20.0.0.9        | 20.0.0.9              | 1           |
 | OpenShift ![OpenShift only](https://img.shields.io/badge/-OpenShift_only-red)   | 4.5 and future fix packs  | 4.5                   | 8,13        |
 | Kubernetes ![IKS only](https://img.shields.io/badge/-IKS_only-blue)             | 1.19 and future fix packs | 1.19                  | 2,12        |
 | IBM MQ LTS                                                                      | 9.1                       | 9.1.0.5 and future FP | 3           |
 | IBM MQ CD ![OpenShift only](https://img.shields.io/badge/-OpenShift_only-red)   | 9.2                       | 9.2.2.0 and future FP | 9           |
 | Docker                                                                          | 19.03                     | 19.03.5 and future FP | 4,5,6,10,14 |
 | Docker                                                                          | 20.10                     | 20.10.2 and future FP | 4,5,6,11,14 |
-| Helm                                                                            | v3                        | v3.3.4 and future FP  | 7           |
+| Helm                                                                            | v3                        | v3.3.4 and future FP  | 7,15        |
 
 |Notes|
 |-|
@@ -71,6 +71,7 @@ The technologies listed are fixed version support only, unless stated otherwise.
 |`(12)` &#124; Kubernetes releases a new version quarterly. When a new version is released `n-2` is deprecated, and `n-3` is unsupported. For more information please see [Kubernetes version information and update actions](https://cloud.ibm.com/docs/containers?topic=containers-cs_versions)|
 |`(13)` &#124; OpenShift releases a new version quarterly. When a new version is released `n-2` is deprecated, and `n-3` is unsupported. For more information please see [Red Hat Openshift on IBM Cloud Version information and update actions](https://cloud.ibm.com/docs/openshift?topic=openshift-openshift_versions), and [Red Hat OpenShift Container Platform Life Cycle Policy](https://access.redhat.com/support/policy/updates/openshift)|
 |`(14)` &#124; IBM Cúram Social Program Management uses Docker only to build container images, IBM Cúram Social Program Management do not use Docker as a container runtime engine.|
+|`(13)` &#124; Due to breaking changes in Helm release `v3.7.0`, IBM Cúram Social Program Management only supports up to Helm `v3.6.3`|
 
 </AccordionItem>
 
@@ -83,7 +84,7 @@ The technologies listed are fixed version support only, unless stated otherwise.
 | IBM MQ                        | 9.1                       | 9.1.0.4 and future FP | 3           |
 | Docker                        | 19.03                     | 19.03.5 and future FP | 4,5,6,10,12 |
 | Docker                        | 20.10                     | 20.10.2 and future FP | 4,5,6,11,12 |
-| Helm                          | v3                        | v3.3.4 and future FP  | 7           |
+| Helm                          | v3                        | v3.3.4 and future FP  | 7,13        |
 
 |Notes|
 |-|
@@ -99,6 +100,7 @@ The technologies listed are fixed version support only, unless stated otherwise.
 |`(10)` &#124; Docker is due to drop support for Docker 19.03 in July 2021. After this date Docker 19.03 is not supported by IBM Cúram Social Program Management.|
 |`(11)` &#124; Support for Docker 20.10 was introducted as part of the SPM@Kubernetes 21.2.0 release.|
 |`(12)` &#124; IBM Cúram Social Program Management uses Docker only to build container images, IBM Cúram Social Program Management do not use Docker as a container runtime engine.|
+|`(13)` &#124; Due to breaking changes in Helm release `v3.7.0`, IBM Cúram Social Program Management only supports up to Helm `v3.6.3`|
 
 </AccordionItem>
 


### PR DESCRIPTION
## v21.6.3

### Added

* Add a startup probe to the `apps` producer and consumers pods

### Changed

* Updated WebSphere Liberty version to include 21.0.0.9
* The following helm-charts have been updated to chart version `21.6.3`: `apps`, `batch`, `mqserver`, `spm`, `uawebapp`, `web`, `xmlserver`.
* Timeout for linkchecker updated from 60 to 120
* Update the readiness probe of the `apps` producer and consumers pods, consider a pod ready if curl to application link gives successful response or if codes 'CWWKZ0001I & CWWKF0011I' are found in message logs.
* Updated the liveness probe to check only the last 1000 lines of the logs file
* Updated support statement for Helm v3 in prerequisite
  * Due to breaking changes in Helm release `v3.7.0`, IBM Cúram Social Program Management only supports up to Helm `v3.6.3`

### Fixed

* Restore setting of environment variable `POD_HOSTNAME` in Liberty `server.xml` for the `apps` producer and consumers pods