### PR TITLE
April 2022 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file
 
+## v21.6.5
+
+### Changed
+
+* The following helm-charts have been updated to chart version `21.6.5`: `apps`, `batch`, `mqserver`, `spm`, `uawebapp`, `web`, `xmlserver`.
+
+### Fixed
+
+* Fixed the issue where `xmlserver` pod termination overwrote the `verbosegc.log` written to by the `main` Ant task.
+* Removed the WebSphere Liberty dataSource setting `isolationLevel="TRANSACTION_REPEATABLE_READ"` [#109](https://github.com/IBM/spm-kubernetes/issues/109) as the default Liberty setting is appropriate for Db2 and Oracle.
+
 ## v21.6.4
 
 ### Breaking Changes

--- a/dockerfiles/Liberty/content/stop-xmlserver.sh
+++ b/dockerfiles/Liberty/content/stop-xmlserver.sh
@@ -3,7 +3,9 @@ set -e
 XMLSERVER_PATH=/opt/ibm/Curam/xmlserver
 
 echo "INFO - Stopping XML Server ..."
-ant -f $XMLSERVER_PATH/xmlserver.xml stop 2>&1 | tee -a tmp/xmlserver.log
+# The start-xmlserver.sh script hard codes the GC settings in the xmlserver.xml java.jvmargs property,
+# so here that is overridden to avoid overwriting the verbosegc.log file.
+ant -f $XMLSERVER_PATH/xmlserver.xml stop -Djava.jvmargs="" 2>&1 | tee -a tmp/xmlserver.log
 if [ $? = 0 ]
 then
   echo "INFO - XML Server stop invoked."

--- a/helm-charts/apps/Chart.yaml
+++ b/helm-charts/apps/Chart.yaml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2019,2020 IBM Corporation
+# Copyright 2019,2022 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 21.6.4
+version: 21.6.5
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/apps/templates/configmaps/configmap-dbconn.yaml
+++ b/helm-charts/apps/templates/configmaps/configmap-dbconn.yaml
@@ -1,7 +1,7 @@
 {{- include "sch.config.init" (list . "apps.sch.chart.config.values") -}}
 ---
 ###############################################################################
-# Copyright 2019,2021 IBM Corporation
+# Copyright 2019,2022 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,14 +38,12 @@ data:
 
       <!-- ========================== Data Sources ========================== -->
       <dataSource id="curamdb" jndiName="jdbc/curamdb"
-        isolationLevel="TRANSACTION_REPEATABLE_READ"
         jdbcDriverRef="CuramJdbcDriver" type="javax.sql.XADataSource"
         statementCacheSize="${env.DS_CURAMDB_CACHE_SIZE}">
         {{- include "apps.dsprops.fragment" (list . "CURAMDB") | nindent 8 }}
       </dataSource>
 
       <dataSource id="DefaultDataSource" jndiName="jdbc/curamtimerdb"
-        isolationLevel="TRANSACTION_REPEATABLE_READ"
         jdbcDriverRef="CuramJdbcDriver" type="javax.sql.XADataSource"
         statementCacheSize="${env.DS_CURAMTIMERDB_CACHE_SIZE}">
         {{- include "apps.dsprops.fragment" (list . "CURAMTIMERDB") | nindent 8 }}

--- a/helm-charts/apps/templates/configmaps/configmap-sessions.yaml
+++ b/helm-charts/apps/templates/configmaps/configmap-sessions.yaml
@@ -1,7 +1,7 @@
 {{- include "sch.config.init" (list . "apps.sch.chart.config.values") -}}
 ---
 ###############################################################################
-# Copyright 2019,2020 IBM Corporation
+# Copyright 2019,2022 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ data:
 
       <dataSource id="curamsessdb" jndiName="jdbc/curamsessdb"
         jdbcDriverRef="CuramJdbcDriver" type="javax.sql.XADataSource"
-        isolationLevel="TRANSACTION_REPEATABLE_READ"
         statementCacheSize="${env.DS_CURAMSESSDB_CACHE_SIZE}">
         {{- include "apps.dsprops.fragment" (list . "CURAMSESSDB") | nindent 8 }}
       </dataSource>

--- a/helm-charts/batch/Chart.yaml
+++ b/helm-charts/batch/Chart.yaml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2019,2020 IBM Corporation
+# Copyright 2019,2022 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 21.6.4
+version: 21.6.5
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/mqserver/Chart.yaml
+++ b/helm-charts/mqserver/Chart.yaml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2019,2021 IBM Corporation
+# Copyright 2019,2022 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 21.6.4
+version: 21.6.5
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/spm/Chart.yaml
+++ b/helm-charts/spm/Chart.yaml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2019,2020 IBM Corporation
+# Copyright 2019,2022 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 21.6.4
+version: 21.6.5
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team
@@ -56,22 +56,22 @@ icon: https://avatars2.githubusercontent.com/u/1459110
 
 dependencies:
   - name: apps
-    version: "~21.6.4"
+    version: "~21.6.5"
     repository: "@local-development"
   - name: batch
-    version: "~21.6.4"
+    version: "~21.6.5"
     repository: "@local-development"
   - name: uawebapp
-    version: "~21.6.4"
+    version: "~21.6.5"
     repository: "@local-development"
   - name: web
-    version: "~21.6.4"
+    version: "~21.6.5"
     repository: "@local-development"
   - name: mqserver
-    version: "~21.6.4"
+    version: "~21.6.5"
     repository: "@local-development"
   - name: xmlserver
-    version: "~21.6.4"
+    version: "~21.6.5"
     repository: "@local-development"
   - name: ibm-sch
     repository: "@sch"

--- a/helm-charts/uawebapp/Chart.yaml
+++ b/helm-charts/uawebapp/Chart.yaml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2019,2020 IBM Corporation
+# Copyright 2019,2022 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 21.6.4
+version: 21.6.5
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/web/Chart.yaml
+++ b/helm-charts/web/Chart.yaml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2019,2020 IBM Corporation
+# Copyright 2019,2022 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 21.6.4
+version: 21.6.5
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/helm-charts/xmlserver/Chart.yaml
+++ b/helm-charts/xmlserver/Chart.yaml
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2019,2020 IBM Corporation
+# Copyright 2019,2022 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ description: |-
   You may obtain a copy of the License at
 
   http://www.apache.org/licenses/LICENSE-2.0
-version: 21.6.4
+version: 21.6.5
 maintainers:
   - name: IBM
   - name: Cúram SPM Dev Team

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spm-kubernetes",
-  "version": "21.6.4",
+  "version": "21.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "spm-kubernetes",
   "private": true,
-  "version": "21.6.4",
+  "version": "21.6.5",
   "license": "Apache 2.0",
   "scripts": {
     "dev": "gatsby develop -H 0.0.0.0",

--- a/src/pages/architecture/openshift-consideration/container-registry.mdx
+++ b/src/pages/architecture/openshift-consideration/container-registry.mdx
@@ -6,7 +6,7 @@ tabs: ['Security','Networking','Authentication','Container Registry','Storage']
 
 ## Container Registry
 
-OpenShift Container Platform provides a built-in [container image registry](https://docs.openshift.com/container-platform/4.5/registry/architecture-component-imageregistry.html) that runs as a standard workload on the cluster.
+OpenShift Container Platform provides a built-in [container image registry](https://docs.openshift.com/container-platform/latest/registry/index.html) that runs as a standard workload on the cluster.
 
 The registry is configured and managed by an infrastructure Operator.
 It provides an out-of-the-box solution for users to manage the images that run their workloads, and runs on top of the existing cluster infrastructure.

--- a/src/pages/architecture/openshift-consideration/networking.mdx
+++ b/src/pages/architecture/openshift-consideration/networking.mdx
@@ -11,4 +11,4 @@ OpenShift Container Platform uses the Multus CNI plug-in to allow chaining of CN
 The default network handles all ordinary network traffic for the cluster. You can define an additional network based on the available CNI plug-ins and attach one or more of these networks to your Pods.
 You can define more than one additional network for your cluster, depending on your needs. This gives you flexibility when you configure Pods that deliver network functionality, such as switching or routing.
 
-Here we can better [Understand multiple networks](https://docs.openshift.com/container-platform/4.5/networking/multiple_networks/understanding-multiple-networks.html) and find out more about [OpenShift network policy](https://docs.openshift.com/container-platform/4.5/networking/network_policy/about-network-policy.html)
+Here we can better [Understand multiple networks](https://docs.openshift.com/container-platform/latest/networking/multiple_networks/understanding-multiple-networks.html) and find out more about [OpenShift network policy](https://docs.openshift.com/container-platform/latest/networking/network_policy/about-network-policy.html)

--- a/src/pages/architecture/openshift-consideration/security.mdx
+++ b/src/pages/architecture/openshift-consideration/security.mdx
@@ -11,4 +11,4 @@ Some level of compliance verification might be needed before you can even bring 
 
 Likewise, you may need to add your own agents, specialized hardware drivers, or encryption features to OpenShift Container Platform, before it can meet your organization’s security standards.
 
-Here [Understanding container security](https://docs.openshift.com/container-platform/4.5/security/container_security/security-understanding.html) can help with pointers to questions teams might have.
+Here [Understanding container security](https://docs.openshift.com/container-platform/latest/security/container_security/security-understanding.html) can help with pointers to questions teams might have.

--- a/src/pages/architecture/openshift-consideration/storage.mdx
+++ b/src/pages/architecture/openshift-consideration/storage.mdx
@@ -9,4 +9,4 @@ tabs: ['Security','Networking','Authentication','Container Registry','Storage']
 Managing storage is a distinct problem from managing compute resources. OpenShift Container Platform uses the Kubernetes `PersistentVolume` (PV) framework to allow cluster administrators to provision persistent storage for a cluster.
 Developers can use `PersistentVolumeClaims` (PVCs) to request PV resources without having specific knowledge of the underlying storage infrastructure.
 
-More information can be found in the [Persistent storage overview](https://docs.openshift.com/container-platform/4.5/storage/understanding-persistent-storage.html) page on OpenShift.
+More information can be found in the [Persistent storage overview](https://docs.openshift.com/container-platform/latest/storage/understanding-persistent-storage.html) page on OpenShift.

--- a/src/pages/build-images/build_images.mdx
+++ b/src/pages/build-images/build_images.mdx
@@ -237,7 +237,7 @@ docker build \
 
 </InlineNotification>
 
-* To build an SPM Docker image for your *built* Universal Access application:
+* To build an SPM Docker image for your _built_ Universal Access application:
   * Copy the `build` directory from the React application to `$SPM_HOME/dockerfiles/HTTPServer`
   * Run the following commands:
 

--- a/src/pages/monitoring/Health Checks.mdx
+++ b/src/pages/monitoring/Health Checks.mdx
@@ -24,4 +24,4 @@ A liveness probe determines if a container is still running. If the liveness pro
 
 More details about the Startup, Readiness and Liveness Probes can be found
 [here](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) on Kubernetes
-site and [here](https://docs.openshift.com/container-platform/4.6/applications/application-health.html) on OpenShift site.
+site and [here](https://docs.openshift.com/container-platform/latest/applications/application-health.html) on OpenShift site.

--- a/src/pages/prereq/kubernetes/kubernetes-overview.mdx
+++ b/src/pages/prereq/kubernetes/kubernetes-overview.mdx
@@ -37,7 +37,7 @@ Example:
 
 <InlineNotification>
 
-**Note:** If version skew exists between `kube-apiserver` instances in an HA cluster, this narrows the allowed `kubelet` versions.
+__Note:__ If version skew exists between `kube-apiserver` instances in an HA cluster, this narrows the allowed `kubelet` versions.
 </InlineNotification>
 
 Example:

--- a/src/pages/prereq/openshift/openshift-overview.mdx
+++ b/src/pages/prereq/openshift/openshift-overview.mdx
@@ -13,7 +13,7 @@ tabs: ['OpenShift Overview','CodeReady Containers']
 </InlineNotification>
 
 OpenShift is a family of containerisation software products developed by RedHat. It's flagship product, OpenShift Container Platform (OCP), can be used to
-configure and deploy IBM® Cúram Social Program Management (SPM). More information about OCP can be found [here](https://docs.openshift.com/container-platform/4.5/welcome/index.html).
+configure and deploy IBM® Cúram Social Program Management (SPM). More information about OCP can be found [here](https://docs.openshift.com/container-platform/latest/welcome/index.html).
 
 CodeReady Containers (CRC) is a minimal cluster that is designed to run on your local workstation as a development environment for OpenShift. Steps to deploy
 SPM using CRC can be found in the [CodeReady Containers tab](/prereq/openshift/codeready-containers). Further information can be found in the [official CRC repository](https://github.com/code-ready/crc).


### PR DESCRIPTION
## v21.6.5

### Changed

* The following helm-charts have been updated to chart version `21.6.5`: `apps`, `batch`, `mqserver`, `spm`, `uawebapp`, `web`, `xmlserver`.

### Fixed

* Fixed the issue where `xmlserver` pod termination overwrote the `verbosegc.log` written to by the `main` Ant task.
* Removed the WebSphere Liberty dataSource setting `isolationLevel="TRANSACTION_REPEATABLE_READ"` [#109](https://github.com/IBM/spm-kubernetes/issues/109) as the default Liberty setting is appropriate for Db2 and Oracle.